### PR TITLE
add php 8.5 support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master, "8.0" ]
+    branches: [ master, "8.0", "8.5" ]
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:8.5-fpm
 
 WORKDIR /app
 
@@ -18,9 +18,8 @@ RUN apt-get update && \
   && rm -rf /var/lib/apt/lists/*
 
 #Update to latest nginx
-RUN echo "deb http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list.d/nginx.list \
-  && echo "deb-src http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list.d/nginx.list \
-  && curl -L https://nginx.org/keys/nginx_signing.key | apt-key add - \
+RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian/ bookworm nginx" > /etc/apt/sources.list.d/nginx.list \
   && apt-get update && apt-get install -y nginx \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,13 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
   && apt-get update && apt-get install -y nginx \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pecl install redis \
+RUN git clone https://github.com/phpredis/phpredis.git /tmp/phpredis \
+  && cd /tmp/phpredis \
+  && phpize \
+  && ./configure \
+  && make && make install \
   && docker-php-ext-enable redis \
+  && rm -rf /tmp/phpredis \
   && docker-php-ext-install zip opcache pcntl sockets pdo pdo_pgsql
 
 RUN sed -i -e 's/# sv_SE.UTF-8 UTF-8/sv_SE.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
   libpq-dev \
   libzip-dev \
   gnupg2 \
+  curl \
   git \
   procps \
   zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,9 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
   && apt-get update && apt-get install -y nginx \
   && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/phpredis/phpredis.git /tmp/phpredis \
-  && cd /tmp/phpredis \
-  && phpize \
-  && ./configure \
-  && make && make install \
+RUN pecl install redis-6.3.0 \
   && docker-php-ext-enable redis \
-  && rm -rf /tmp/phpredis \
-  && docker-php-ext-install zip opcache pcntl sockets pdo pdo_pgsql
+  && docker-php-ext-install zip pcntl sockets pdo pdo_pgsql
 
 RUN sed -i -e 's/# sv_SE.UTF-8 UTF-8/sv_SE.UTF-8 UTF-8/' /etc/locale.gen && \
   dpkg-reconfigure --frontend=noninteractive locales

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
   && apt-get update && apt-get install -y nginx \
   && rm -rf /var/lib/apt/lists/*
 
+#Add PostgreSQL repo for pg18 client
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+  && apt-get update && apt-get install -y postgresql-client-18 \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN pecl install redis-6.3.0 \
   && docker-php-ext-enable redis \
   && docker-php-ext-install zip pcntl sockets pdo pdo_pgsql

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
 
 #Add PostgreSQL repo for pg18 client
 RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
-  && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+  && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
   && apt-get update && apt-get install -y postgresql-client-18 \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- update base image to php:8.5-fpm
- update nginx repo to bookworm (debian 12)
- fix deprecated apt-key usage